### PR TITLE
Fixed returning queried person

### DIFF
--- a/SegarsProgram3.pl
+++ b/SegarsProgram3.pl
@@ -42,10 +42,8 @@ mother(X, Y) :- parent(X, Y), female(X).
 father(X, Y) :- parent(X, Y), male(X).
 grandmother(X, Y) :- parent(X, Z), parent(Z, Y), female(X).
 grandfather(X, Y) :- parent(X, Z), parent(Z, Y), male(X).
-sister(X, X) :-, fail.
-sister(X, Y) :- parent(Z, X), parent(Z, Y), female(X).
-brother(X, Y) :- parent(Z, X), parent(Z, Y), male(X).
-cousin(X, Y) :- grandmother(Z, X), grandmother(Z, Y).
-cousin(X, Y) :- grandfather(Z, X), grandfather(Z, Y).
+sister(X, Y) :- mother(A, X), mother(A, Y), father(B, X), father(B, Y), female(X), not(X=Y). %% not(X=Y) so the person in the query isn't also returned
+brother(X, Y) :- mother(A, X), mother(A, Y), father(B, X), father(B, Y), male(X), not(X=Y). 
+cousin(X, Y) :- grandmother(A, X), grandmother(A, Y), grandfather(B, X), grandfather(B, Y), not(X=Y), not(sister(X, Y)), not(brother(X, Y)). %% not(sister) and not(brother) so it doesn't return siblings of person in query
 son(X, Y) :- parent(Y, X), male(X).
 daughter(X, Y) :- parent(Y, X), female(X).


### PR DESCRIPTION
Added functionality to not return the person queried when checking for siblings and to only return each person once when checking for sibling or cousin relationships